### PR TITLE
Allow manual submit input after correction threshold

### DIFF
--- a/apps/web/src/components/practice/hooks/__tests__/useInteractionPhase.test.ts
+++ b/apps/web/src/components/practice/hooks/__tests__/useInteractionPhase.test.ts
@@ -405,6 +405,35 @@ describe('useInteractionPhase', () => {
       }
     })
 
+    it('accepts any digit input once manual submit is required', async () => {
+      const { result } = renderHook(() => useInteractionPhase())
+
+      act(() => {
+        result.current.loadProblem(simpleProblem, 0, 0)
+      })
+
+      // Force manual submit by exceeding the correction threshold
+      for (let i = 0; i <= MANUAL_SUBMIT_THRESHOLD; i++) {
+        act(() => {
+          result.current.handleDigit('5') // invalid digit
+        })
+        await act(async () => {
+          vi.advanceTimersByTime(301)
+        })
+      }
+
+      // Now that manual submit is required, any digit should be accepted
+      act(() => {
+        result.current.handleDigit('9')
+      })
+
+      if (result.current.phase.phase === 'inputting') {
+        expect(result.current.phase.attempt.manualSubmitRequired).toBe(true)
+        expect(result.current.phase.attempt.userAnswer).toBe('9')
+        expect(result.current.phase.attempt.rejectedDigit).toBeNull()
+      }
+    })
+
     it('does nothing in non-input phases', () => {
       const { result } = renderHook(() => useInteractionPhase())
 


### PR DESCRIPTION
## Summary
- allow keypad input to bypass prefix validation after exceeding the manual submit threshold so students can type any digits once the submit button is shown
- clear answers when entering help mode and make exiting help mode clear any lingering input even if the phase already returned to inputting
- add a regression test covering manual-submit digit acceptance

## Testing
- pnpm --filter @soroban/web test -- --run src/components/practice/hooks/__tests__/useInteractionPhase.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69519150b2a8832b8464265174b3e91d)